### PR TITLE
Fix CW-465. Use the network name when collection name is not set in the parameter.

### DIFF
--- a/src/main/java/org/cytoscape/rest/internal/resource/NetworkResource.java
+++ b/src/main/java/org/cytoscape/rest/internal/resource/NetworkResource.java
@@ -1538,8 +1538,11 @@ public class NetworkResource extends AbstractResource {
 				CySubNetwork subnet = (CySubNetwork) networks[0];
 				final CyRootNetwork rootNet = subnet.getRootNetwork();
 				String rootNetName = rootNet.getRow(rootNet).get(CyNetwork.NAME, String.class);
-				rootNet.getRow(rootNet).set(CyNetwork.NAME, collectionName);
-				if (rootNetName == null || rootNetName.trim().length() == 0) {
+				if ( collectionName != null && collectionName.trim().length() > 0) {
+                    // Set the name of the root network to the collection
+					rootNet.getRow(rootNet).set(CyNetwork.NAME, collectionName);
+				}	
+				if ((rootNetName == null || rootNetName.trim().length() == 0) && collectionName != null ) {
 					// The root network does not have a name yet, set it the same
 					// as the base subnetwork
 					rootNet.getRow(rootNet).set(CyNetwork.NAME, collectionName);


### PR DESCRIPTION
The bug is in the addNework function. collection name was overwritten by suid when collection name is not set.  addNetwork is called from createNetwork function. CyWeb uses createNetwork endpoint to create cx2 networks in Cytoscape. 